### PR TITLE
Fix typo in mediaSession.js

### DIFF
--- a/lib/mediaSession.js
+++ b/lib/mediaSession.js
@@ -160,7 +160,7 @@ MediaSession.prototype = _.extend(MediaSession.prototype, {
         log(this.sid + ': Terminating session');
         this.pc.close();
         _.each(this.streams, function (stream) {
-            self.onStreamRemoved({stream: stream});
+            self._onStreamRemoved({stream: stream});
         });
         JingleSession.prototype.end.call(this, changes.reason, true);
         cb();


### PR DESCRIPTION
The onSessionTerminate method called the private _onStreamRemoved method but ommited the underscore in it's name.
