### PR TITLE
Add callbacks for addStream2 / removeStream2 methods

### DIFF
--- a/lib/mediaSession.js
+++ b/lib/mediaSession.js
@@ -131,15 +131,23 @@ MediaSession.prototype = _.extend(MediaSession.prototype, {
     addStream: function (stream) {
         this.pc.addStream(stream);
     },
-    addStream2: function (stream) {
+    addStream2: function (stream, cb) {
         // note that this method is highly experimental and may 
         // go away without notice
         // it is basically a renegotiation-capable version of addStream
+        cb = cb || function () {};
         var self = this;
         this.pc.addStream(stream);
         this.pc.handleOffer({type: 'offer', jingle: this.pc.remoteDescription}, function (err) {
-            console.log('handleOffer', err);
+            if (err) {
+                console.log('handleOfferError', err);
+                return cb(err);
+            }
             self.pc.answer(function (err, answer) {
+                if (err) {
+                    console.log('answerError', err);
+                    return cb(err);
+                }
                 console.log('answer', answer);
                 answer.jingle.contents.forEach(function (content) {
                     //console.log('answer', content.name, 'msid', content.description.sources[0].parameters[1].value.split(' ')[0]);
@@ -152,16 +160,18 @@ MediaSession.prototype = _.extend(MediaSession.prototype, {
                     }
                 });
                 self.send('source-add', answer.jingle);
+                cb();
             });
         });
     },
     removeStream: function (stream) {
         this.pc.removeStream(stream);
     },
-    removeStream2: function (stream) {
+    removeStream2: function (stream, cb) {
         // note that this method is highly experimental and may 
         // go away without notice
         // it is basically a renegotiation-capable version of removeStream
+        cb = cb || function () {};
         var self = this;
         var desc = this.pc.localDescription;
         console.log('remove stream id', stream.id);
@@ -178,9 +188,17 @@ MediaSession.prototype = _.extend(MediaSession.prototype, {
         this.pc.removeStream(stream);
 
         this.pc.handleOffer({type: 'offer', jingle: this.pc.remoteDescription}, function (err) {
-            console.log('handleOffer', err);
+            if (err) {
+                console.log('handleOfferError', err);
+                return cb(err);
+            }
             self.pc.answer(function (err, answer) {
+                if (err) {
+                    console.log('answerError', err);
+                    return cb(err);
+                }
                 console.log('answer', answer);
+                cb();
             });
         });
     },
@@ -406,7 +424,8 @@ MediaSession.prototype = _.extend(MediaSession.prototype, {
             });
         });
     },
-    switchStream: function (oldStream, newStream) {
+    switchStream: function (oldStream, newStream, cb) {
+        cb = cb || function () {};
         var self = this;
         // pluck the <source/> to be removed
         // which is where oldstream.label == localDescription.contents[1].description.sources[0].parameters[1].value.split(" ")[0]
@@ -430,8 +449,15 @@ MediaSession.prototype = _.extend(MediaSession.prototype, {
         //console.log(newStream);
         this.pc.addStream(newStream);
         this.pc.handleOffer({type: 'offer', jingle: this.pc.remoteDescription}, function (err) {
-            console.log('handleOffer', err);
+            if (err) {
+                console.log('handleOfferError', err);
+                return cb(err);
+            }
             self.pc.answer(function (err, answer) {
+                if (err) {
+                    console.log('answerError', answer);
+                    return cb(err);
+                }
                 console.log('answer', answer);
                 answer.jingle.contents.forEach(function (content) {
                     delete content.transport;
@@ -439,6 +465,7 @@ MediaSession.prototype = _.extend(MediaSession.prototype, {
                 });
                 console.log(JSON.parse(JSON.stringify(answer.jingle)));
                 self.send('source-add', answer.jingle);
+                cb();
             });
         });
     },


### PR DESCRIPTION
So we can queue these things to not happen multiple times during renegotiation.
