### PR TITLE
Add check for a response with a more specific jid

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,7 +235,6 @@ SessionManager.prototype.process = function (req) {
     var rid = req.id;
     var sender = req.from.full || req.from;
 
-
     if (req.type === 'error') {
         var isTieBreak = req.error && req.error.jingleCondition === 'tie-break';
         if (session && session.pending && isTieBreak) {
@@ -281,6 +280,11 @@ SessionManager.prototype.process = function (req) {
                 condition: 'item-not-found',
                 jingleCondition: 'unknown-session'
             });
+        }
+
+        // Check if the sender is a more specific peer Id (i.e., full jid vs bare jid)
+        if (sender.indexOf(session.peerID) === 0 && session.peerID !== sender) {
+            session.peerID = sender;
         }
 
         // Check if someone is trying to hijack a session.


### PR DESCRIPTION
I encountered an issue regarding session establishment - our xmpp client wants to initiate a request to a peer (using jid), but they're using the bare jid, effectively broadcasting a peer connection request to any client connected for that user. The response comes back with a full jid, identifying a specific client to which signaling should occur.

Example: User A (`userA@example/desktopClient`) requests video to User B (`userB@example`) and User B responds from `userB@example/mobile`. User A should update the session with User B to signal on `userB@example/mobile`, instead of `userB@example`.

Please let me know what you think of this. I'm still getting my feet wet with XMPP, but I ran this by our xmpp server guy and he said it made sense, but he's not familiar with jingle.